### PR TITLE
Fix issue with pseudo selector replacement failure.

### DIFF
--- a/css-slap-chop.js
+++ b/css-slap-chop.js
@@ -12,7 +12,7 @@ function readFile(path, cb) {
         if (err) cb(err)
         else cb(null, data.toString('utf8'))
     })
-} 
+}
 
 //
 // the public api
@@ -22,20 +22,20 @@ module.exports = {
     //
     // panda.parse({html:path_to_html, css:path_to_css}, function(err, data) {
     //     console.log(data.used)
-    //     console.log(data.unused)   
+    //     console.log(data.unused)
     // })
     parse: function(options, cb) {
-       
+
         var ignore = options.ignore ? require(options.ignore).selectors : []
-        
-        function readCSS(cb) { 
+
+        function readCSS(cb) {
             readFile(options.css, cb)
         }
 
-        function readHTML(cb) { 
+        function readHTML(cb) {
             readFile(options.html, cb)
         }
-       
+
         function css(cb) {
             readCSS(function(err, css){
                 if (err) cb(err)
@@ -51,10 +51,10 @@ module.exports = {
         }
 
         function parseCSS(str, cb) {
-            var rules  = cssom.parse(str).cssRules.map(function(r) { 
-                return r.selectorText 
+            var rules  = cssom.parse(str).cssRules.map(function(r) {
+                return r.selectorText
             })
-            cb(null, rules) 
+            cb(null, rules)
         }
 
         function parseHTML(str, cb) {
@@ -66,20 +66,20 @@ module.exports = {
 
         // read in the css rules and html at the same time
         async.parallel([css, html], function(err, results){
-            
+
             if (err) cb(err)
-            
+
             var rules = results[0]
             ,   $     = results[1]
             ,   r     = { used:ignore, unused:[] }
-            
+
             // then loop thru the css selectors using jquery to test for their existance in the html doc
-            for (var i = 0, l = rules.length; i < l; i++) {       
-                
+            for (var i = 0, l = rules.length; i < l; i++) {
+
                 var rule = rules[i]
-                ,   query = (rule.search(':hover') > 0) ? rule.replace(':hover','') : rule
+                ,   query = rule.replace(/:[\w]*/g,'')
                 ,   found = !!($(query).length >= 1)
-                
+
                 if (found) {
                     r.used.push(rule)
                 }
@@ -87,12 +87,12 @@ module.exports = {
                     r.unused.push(rule)
                 }
             }
-            
+
             cb(null, r)
         })
     }
     ,
-    // 
+    //
     // returns used selectors as array
     //
     used: function(options, callback) {
@@ -101,7 +101,7 @@ module.exports = {
         })
     }
     ,
-    // 
+    //
     // returns unused selectors as array
     //
     unused: function(options, callback) {
@@ -120,21 +120,21 @@ module.exports = {
                 var rules     = cssom.parse(str).cssRules
                 ,   usedRules = []
                 ,   css       = ''
-                
+
                 rules.forEach(function(rule) {
                     var hasSelector = _.indexOf(selectors, rule.selectorText)
                     if (hasSelector >= 0) usedRules.push(rule)
                 })
-                 
+
                 usedRules.forEach(function(rule) {
                     css += rule.selectorText + " {\n"
-                    
+
                     var allkeys = _.keys(rule.style)
                     ,   offset  = rule.style.length
                     ,   len     = allkeys.length
                     ,   rest    = len - offset
                     ,   keys    = _.rest(allkeys, rest)
-                    
+
                     _.each(keys, function(k, i) {
                         css += "    " + k + ":" + rule.style[k] + ";\n"
                     })
@@ -143,11 +143,11 @@ module.exports = {
                 })
                 callback(null, css)
             })
-        }) 
+        })
     }
     ,
     cli: function() {
-        var program = require('commander')    
+        var program = require('commander')
 
         program
           .version('0.1.0')
@@ -156,7 +156,7 @@ module.exports = {
           .option('-c, --css <path>', 'REQUIRED! The css file to analyze.')
           .option('-i, --ignore <path>', 'Optional JSON file of selectors to ignore.')
           .parse(process.argv)
-        
+
         if (process.argv.length === 2) {
             console.log('Try running --help for all the options.')
         }
@@ -164,7 +164,7 @@ module.exports = {
             var opts = { html:program.html, css:program.css }
 
             if (program.ignore) opts.ignore = program.ignore
-            
+
             this.tidy(opts, function(err, css) {
                 if (err) console.error(err)
                 console.log(css)

--- a/test/test.css
+++ b/test/test.css
@@ -19,6 +19,10 @@ ul li a:hover {
     text-decoration:underline;
 }
 
+ul li a:active {
+    color:red;
+}
+
 .hidden-thing {
     display:none;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -12,13 +12,13 @@ describe('panda', function(){
     describe('used()', function() {
         it('should return all used rules', function(done){
             panda.used({css:css, html:html}, function(err, used) {
-                used.length.should.eql(5)
+                used.length.should.eql(6)
                 done()
             })
         })
         it('should return all used rules with ignore rules', function(done){
             panda.used({css:css, html:html, ignore:ignore}, function(err, used) {
-                used.length.should.eql(7)
+                used.length.should.eql(8)
                 done()
             })
         })

--- a/test/used.css
+++ b/test/used.css
@@ -19,3 +19,7 @@ ul li a:hover {
     text-decoration:underline;
 }
 
+ul li a:active {
+    color:red;
+}
+


### PR DESCRIPTION
This is to fix the issue that I 
I added a new css rule to the tests:

``` css
ul li a:active {
    color:red;
}
```

And changed the call to remove pseudo selectors from the css rule to be agnostic of the actual pseudo condition:

``` javascript
query = rule.replace(/:[\w]*/g,'')
```

Changed the tests to expect a new matching rule. **All green**

Cleaned up extra spaces at ends of line.
